### PR TITLE
Add namespace to kustomizations

### DIFF
--- a/variants/dev-small/kustomization.yaml
+++ b/variants/dev-small/kustomization.yaml
@@ -9,10 +9,12 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: listener-localhost.json
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: num-partitions-1.json

--- a/variants/scale-1/kustomization.yaml
+++ b/variants/scale-1/kustomization.yaml
@@ -11,4 +11,5 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: kafka-scale1-overrides.json

--- a/variants/scale-2/kustomization.yaml
+++ b/variants/scale-2/kustomization.yaml
@@ -11,4 +11,5 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: kafka-scale2-overrides.json


### PR DESCRIPTION
Without this change, these kustomiations fail to apply their patches
with errors like:

```
Error: no matches for OriginalId apps_v1_StatefulSet|~X|kafka; no
matches for CurrentId apps_v1_StatefulSet|~X|kafka; failed to find
unique target for patch apps_v1_StatefulSet|kafka
```